### PR TITLE
access_token name now a variable

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,8 @@ exports.register = function (plugin, options, next) {
         Hoek.assert(options, 'Missing bearer auth strategy options');
         Hoek.assert(typeof options.validateFunc === 'function', 'options.validateFunc must be a valid function in bearer scheme');
 
+        options.accessTokenName = options.accessTokenName || "access_token";
+
         var settings = Hoek.clone(options);
 
         var scheme = {
@@ -16,9 +18,9 @@ exports.register = function (plugin, options, next) {
                 var req = request.raw.req;
                 var authorization = req.headers.authorization;
 
-                if(!authorization && request.query.access_token){
-                    authorization = "Bearer " + request.query.access_token;
-                    delete request.query.access_token
+                if(!authorization && request.query[settings.accessTokenName]){
+                    authorization = "Bearer " + request.query[settings.accessTokenName];
+                    delete request.query[settings.accessTokenName];
                 }
 
                 if (!authorization) {
@@ -66,7 +68,3 @@ exports.register = function (plugin, options, next) {
 exports.register.attributes = {
     pkg: require('../package.json')
 };
-
-
-
-


### PR DESCRIPTION
I'm not sure this is the best way but having allowing access_token to be renamed makes it fit in with your API variable style, accessToken etc.
