### PR TITLE
Multi auth header

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,10 +40,6 @@ exports.register = function (plugin, options, next) {
                     return reply(Boom.unauthorized(null, 'Bearer'));
                 }
 
-                if (parts.length !== 2 || parts[1].length < 1) {
-                    return reply(Boom.badRequest('Bad HTTP authentication header format', 'Bearer'));
-                }
-
                 var token = parts[1];
 
                 settings.validateFunc.call(request, token, function (err, isValid, credentials) {

--- a/test/index.js
+++ b/test/index.js
@@ -98,6 +98,15 @@ describe('Bearer', function () {
     });
 
     it('returns 200 and success with correct bearer token header set in multiple authorization header', function (done) {
+        var request = { method: 'POST', url: '/basic', headers: { authorization: "Bearer 12345678; FD AF6C74D1-BBB2-4171-8EE3-7BE9356EB018" } };
+        server.inject(request, function (res) {
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal('success');
+            done();
+        });
+    });
+
+    it('returns 200 and success with correct bearer token header set in multiple places of the authorization header', function (done) {
         var request = { method: 'POST', url: '/basic', headers: { authorization: "FD AF6C74D1-BBB2-4171-8EE3-7BE9356EB018; Bearer 12345678" } };
         server.inject(request, function (res) {
             expect(res.statusCode).to.equal(200);
@@ -131,10 +140,10 @@ describe('Bearer', function () {
         });
     });
 
-    it('returns 400 error with incorrect bearer token type', function (done) {
+    it('returns 401 error with bearer token type of object (invalid token)', function (done) {
         var request = { method: 'POST', url: '/basic', headers: { authorization: 'Bearer {test: 1}' } };
         server.inject(request, function (res) {
-            expect(res.statusCode).to.equal(400);
+            expect(res.statusCode).to.equal(401);
             done();
         });
     });


### PR DESCRIPTION
I've added support for multiple authorization header fields and, in doing so, strictly capturing the bearer value, which enforces the format and negates the need for the badRequest exception (capturing that state as unauthorized).
