### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ server.pack.register(require('hapi-auth-bearer-token'), function (err) {
 
     server.auth.strategy('simple', 'bearer-access-token', {
         allowQueryToken: true,              // optional, true by default
-        allowMultipleHeaders: false,        // optional, true by default
+        allowMultipleHeaders: false,        // optional, false by default
         accessTokenName: 'access_token',    // optional, 'access_token' by default
         validateFunc: function( token, callback ) {
         


### PR DESCRIPTION
By default, options.allowMultipleHeaders if false if not specified. Fixing mistake in example code which says that it is true by default.

Checked source code and found this to confirm (lib/index.js: 13).

"options.allowMultipleHeaders = options.allowMultipleHeaders === true ? true : false;"
