### PR TITLE
Allow custom token type

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Bearer authentication requires validating a token passed in by either the bearer
     - `accessTokenName` (Default: 'access_token') - Rename the token query parameter key e.g. 'sample_token_name' would rename the token query parameter to /route1?sample_token_name=12345678.
     - `allowQueryToken` (Default: true) - Disable accepting token by query parameter, forcing token to be passed in through authorization header.
     - `allowMultipleHeaders` (Default: false) - Allow multiple authorization headers in request, e.g. `Authorization: FD AF6C74D1-BBB2-4171-8EE3-7BE9356EB018; Bearer 12345678`
+    - `tokenType` (Default: 'Bearer') - Allow custom token type, e.g. `Authorization: Basic 12345678`
 
 For convenience, the `request` object can be accessed from `this` within validateFunc. This allows some greater flexibility with authentication, such different authentication checks for different routes.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ exports.register = function (server, options, next) {
         options.accessTokenName = options.accessTokenName || "access_token";
         options.allowQueryToken = options.allowQueryToken === false ? false : true;
         options.allowMultipleHeaders = options.allowMultipleHeaders === true ? true : false;
+        options.tokenType = options.tokenType || 'Bearer';
 
         var settings = Hoek.clone(options);
 
@@ -23,12 +24,12 @@ exports.register = function (server, options, next) {
                 if(settings.allowQueryToken
                     && !authorization
                     && request.query[settings.accessTokenName]){
-                    authorization = "Bearer " + request.query[settings.accessTokenName];
+                    authorization = options.tokenType + " " + request.query[settings.accessTokenName];
                     delete request.query[settings.accessTokenName];
                 }
                 
                 if (!authorization) {
-                    return reply(Boom.unauthorized(null, 'Bearer'));
+                    return reply(Boom.unauthorized(null, options.tokenType));
                 }
 
                 if(settings.allowMultipleHeaders) {
@@ -40,8 +41,8 @@ exports.register = function (server, options, next) {
 
                 var parts = authorization.split(/\s+/);
 
-                if (parts[0].toLowerCase() !== 'bearer') {
-                    return reply(Boom.unauthorized(null, 'Bearer'));
+                if (parts[0].toLowerCase() !== options.tokenType.toLowerCase()) {
+                    return reply(Boom.unauthorized(null, options.tokenType));
                 }
 
                 var token = parts[1];
@@ -53,7 +54,7 @@ exports.register = function (server, options, next) {
                     }
 
                     if (!isValid) {
-                        return reply(Boom.unauthorized('Bad token', 'Bearer'), { credentials: credentials });
+                        return reply(Boom.unauthorized('Bad token', options.tokenType), { credentials: credentials });
                     }
 
                     if (!credentials

--- a/test/index.js
+++ b/test/index.js
@@ -83,6 +83,11 @@ describe('Bearer', function () {
                 allowMultipleHeaders: true
             });
 
+            server.auth.strategy('custom_token_type', 'bearer-access-token', {
+                validateFunc: defaultValidateFunc,
+                tokenType: 'Basic'
+            });
+
             server.route([
                 { method: 'POST', path: '/basic', handler: defaultHandler, config: { auth: 'default' } },
                 { method: 'POST', path: '/basic_default_auth', handler: defaultHandler, config: { } },
@@ -93,7 +98,8 @@ describe('Bearer', function () {
                 { method: 'GET', path: '/no_credentials', handler: defaultHandler, config: { auth: 'no_credentials' } },
                 { method: 'GET', path: '/query_token_disabled', handler: defaultHandler, config: { auth: 'query_token_disabled' } },
                 { method: 'GET', path: '/query_token_enabled', handler: defaultHandler, config: { auth: 'query_token_enabled' } },
-                { method: 'GET', path: '/multiple_headers_enabled', handler: defaultHandler, config: { auth: 'multiple_headers' } }
+                { method: 'GET', path: '/multiple_headers_enabled', handler: defaultHandler, config: { auth: 'multiple_headers' } },
+                { method: 'GET', path: '/custom_token_type', handler: defaultHandler, config: { auth: 'custom_token_type' } }
             ]);
 
             done();
@@ -265,4 +271,22 @@ describe('Bearer', function () {
             done();
         })
     });
+
+    it('return unauthorized when different token type is used', function (done) {
+        var request_header_token  = { method: 'GET', url: '/custom_token_type', headers: { authorization: 'Bearer 12345678' } };
+        server.inject(request_header_token, function(res) {
+            expect(res.statusCode).to.equal(401);
+            done();
+        })
+    });
+
+    it('return 200 when correct token type is used', function (done) {
+        var request_header_token  = { method: 'GET', url: '/custom_token_type', headers: { authorization: 'Basic 12345678' } };
+        server.inject(request_header_token, function(res) {
+            expect(res.statusCode).to.equal(200);
+            done();
+        })
+    });
+
+
 });


### PR DESCRIPTION
This enables custom token type, e.g. `Authorization: Basic 12345678`, while 'Bearer' remains as default.
