### PR TITLE
Adding session support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Bearer authentication requires validating a token passed in by either the bearer
     - `accessTokenName` (Default: 'access_token') - Rename the token query parameter key e.g. 'sample_token_name' would rename the token query parameter to /route1?sample_token_name=12345678.
     - `allowQueryToken` (Default: true) - Disable accepting token by query parameter, forcing token to be passed in through authorization header.
     - `allowMultipleHeaders` (Default: false) - Allow multiple authorization headers in request, e.g. `Authorization: FD AF6C74D1-BBB2-4171-8EE3-7BE9356EB018; Bearer 12345678`
+    - `allowSessionSupport` (Default: false) - Allows your token-based api to support browser sessions. Simply add a token to your session at login. `response(200).state('session', {'access_token': token});` and set `accessTokenName` accordingly. `res(200).unstate('session');` at logout.
     - `tokenType` (Default: 'Bearer') - Allow custom token type, e.g. `Authorization: Basic 12345678`
 
 For convenience, the `request` object can be accessed from `this` within validateFunc. If you want to use this, you must use the `function` keyword instead of the arrow syntax. This allows some greater flexibility with authentication, such different authentication checks for different routes.
@@ -38,6 +39,7 @@ server.register(AuthBearer, (err) => {
     server.auth.strategy('simple', 'bearer-access-token', {
         allowQueryToken: true,              // optional, true by default
         allowMultipleHeaders: false,        // optional, false by default
+        allowSessionSupport: false,         // optional, false by default
         accessTokenName: 'access_token',    // optional, 'access_token' by default
         validateFunc: function (token, callback) {
 
@@ -75,6 +77,10 @@ server.start((err) => {
     }
     console.log('Server started at: ' + server.info.uri);
 })
+```
+
+```javascript
+
 ```
 
 License MIT @ John Brett 2014

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,6 +45,13 @@ internals.implementation = (server, options) => {
                 delete request.query[settings.accessTokenName];
             }
 
+            if (!authorization 
+                && settings.allowSessionSupport 
+                && request.state.session 
+                && request.state.session[settings.accessTokenName]) {
+                authorization = options.tokenType + ' ' + request.state.session[settings.accessTokenName];
+            }
+
             if (!authorization) {
                 return reply(Boom.unauthorized(null, options.tokenType));
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,9 +45,9 @@ internals.implementation = (server, options) => {
                 delete request.query[settings.accessTokenName];
             }
 
-            if (!authorization 
-                && settings.allowSessionSupport 
-                && request.state.session 
+            if (!authorization
+                && settings.allowSessionSupport
+                && request.state.session
                 && request.state.session[settings.accessTokenName]) {
                 authorization = options.tokenType + ' ' + request.state.session[settings.accessTokenName];
             }


### PR DESCRIPTION
While I prefer to use bearer-tokens when communicating with my api's via non-browser clients, it's nice to be able to rely on hapijs session support in the browser. This pr adds support for storing tokens in a session during login and having them detected via the authenticate() method under the covers.