### PR TITLE
Pass auth artifacts to Hapi.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Bearer authentication requires validating a token passed in by either the bearer
         - `credentials` - a credentials object passed back to the application in `request.auth.credentials`. Typically, `credentials` are only
           included when `isValid` is `true`, but there are cases when the application needs to know who tried to authenticate even when it fails
           (e.g. with authentication mode `'try'`).
+        - `artifacts` - optional [authentication](http://hapijs.com/tutorials/auth) related data that is not part of the user's credential.
 - `options` - (optional)
     - `accessTokenName` (Default: 'access_token') - Rename the token query parameter key e.g. 'sample_token_name' would rename the token query parameter to /route1?sample_token_name=12345678.
     - `allowQueryToken` (Default: true) - Disable accepting token by query parameter, forcing token to be passed in through authorization header.
@@ -48,10 +49,10 @@ server.register(AuthBearer, (err) => {
             // Use a real strategy here,
             // comparing with a token from your database for example
             if (token === "1234") {
-                return callback(null, true, { token: token });
+                return callback(null, true, { token: token }, { artifact1: 'an artifact' });
             }
             
-            return callback(null, false, { token: token });
+            return callback(null, false, { token: token }, { artifact1: 'an artifact' });
         }
     });
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,14 +64,14 @@ internals.implementation = (server, options) => {
 
             const token = parts[1];
 
-            settings.validateFunc.call(request, token, (err, isValid, credentials) => {
+            settings.validateFunc.call(request, token, (err, isValid, credentials, artifacts) => {
 
                 if (err) {
-                    return reply(err, { credentials: credentials, log: { tags: ['auth', 'bearer'], data: err } });
+                    return reply(err, { credentials, log: { tags: ['auth', 'bearer'], data: err } });
                 }
 
                 if (!isValid) {
-                    return reply(Boom.unauthorized('Bad token', options.tokenType), { credentials: credentials });
+                    return reply(Boom.unauthorized('Bad token', options.tokenType), { credentials, artifacts });
                 }
 
                 if (!credentials
@@ -79,7 +79,7 @@ internals.implementation = (server, options) => {
                     return reply(Boom.badImplementation('Bad token string received for Bearer auth validation'), { log: { tags: 'token' } });
                 }
 
-                return reply.continue({ credentials: credentials });
+                return reply.continue({ credentials, artifacts });
             });
         }
     };


### PR DESCRIPTION
This enables Hapi auth artifacts. [Quoting](http://hapijs.com/tutorials/auth) hapijs.com:
> Additionally, you may also have an `artifacts` key, which can contain any authentication related data that is not part of the user's credentials.

And [this](http://hapijs.com/api/9.5.1#serverinjectoptions-callback):
> `artifacts` - an optional artifacts object containing authentication artifact information. The `artifacts` are used to bypass the default authentication strategies, and are validated directly as if they were received via an authentication scheme. Ignored if set without `credentials`. Defaults to no artifacts.