### PR TITLE
Allow chaining of auth strategies fixes #88

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Bearer authentication requires validating a token passed in by either the bearer
     - `allowQueryToken` (Default: true) - Disable accepting token by query parameter, forcing token to be passed in through authorization header.
     - `allowMultipleHeaders` (Default: false) - Allow multiple authorization headers in request, e.g. `Authorization: FD AF6C74D1-BBB2-4171-8EE3-7BE9356EB018; Bearer 12345678`
     - `tokenType` (Default: 'Bearer') - Allow custom token type, e.g. `Authorization: Basic 12345678`
+    - `allowChaining` (Default: false) - Allow attempt of additonal authentication strategies 
 
 For convenience, the `request` object can be accessed from `this` within validateFunc. If you want to use this, you must use the `function` keyword instead of the arrow syntax. This allows some greater flexibility with authentication, such different authentication checks for different routes.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,7 @@ const Hoek = require('hoek');
 
 const internals = {};
 
-
-exports.register = function (server, options, next) {
+exports.register = (server, options, next) => {
 
     server.auth.scheme('bearer-access-token', internals.implementation);
     next();
@@ -71,7 +70,7 @@ internals.implementation = (server, options) => {
                 }
 
                 if (!isValid) {
-                    const message = (request.route.settings.auth.strategies.length > 1 && options.allowChaining) ? null : 'Bad token';
+                    const message = (options.allowChaining && request.route.settings.auth.strategies.length > 1) ? null : 'Bad token';
 
                     return reply(Boom.unauthorized(message, options.tokenType), { credentials, artifacts });
                 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,9 @@ internals.implementation = (server, options) => {
                 }
 
                 if (!isValid) {
-                    return reply(Boom.unauthorized(null, options.tokenType), { credentials, artifacts });
+                    const message = (request.route.settings.auth.strategies.length > 1 && options.allowChaining) ? null : 'Bad token';
+
+                    return reply(Boom.unauthorized(message, options.tokenType), { credentials, artifacts });
                 }
 
                 if (!credentials

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,7 +71,7 @@ internals.implementation = (server, options) => {
                 }
 
                 if (!isValid) {
-                    return reply(Boom.unauthorized('Bad token', options.tokenType), { credentials, artifacts });
+                    return reply(Boom.unauthorized(null, options.tokenType), { credentials, artifacts });
                 }
 
                 if (!credentials

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "devDependencies": {
     "code": "3.0.2",
-    "hapi": "^13.1.0",
+    "hapi": "^14.0.0",
     "lab": "^10.2.0"
   },
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -72,7 +72,8 @@ before((done) => {
         });
 
         server.auth.strategy('always_reject', 'bearer-access-token', {
-            validateFunc: alwaysRejectValidateFunc
+            validateFunc: alwaysRejectValidateFunc,
+            allowChaining: true
         });
 
         server.auth.strategy('with_error_strategy', 'bearer-access-token', {
@@ -260,7 +261,10 @@ it('returns 401 handles when isValid false passed to validateFunc', (done) => {
         expect(res.result).to.equal({
             statusCode: 401,
             error: 'Unauthorized',
-            message: 'Missing authentication'
+            message: 'Bad token',
+            attributes: {
+                error: 'Bad token'
+            }
         });
         expect(res.statusCode).to.equal(401);
         done();

--- a/test/index.js
+++ b/test/index.js
@@ -72,8 +72,7 @@ before((done) => {
         });
 
         server.auth.strategy('always_reject', 'bearer-access-token', {
-            validateFunc: alwaysRejectValidateFunc,
-            allowChaining: true
+            validateFunc: alwaysRejectValidateFunc
         });
 
         server.auth.strategy('with_error_strategy', 'bearer-access-token', {
@@ -113,6 +112,11 @@ before((done) => {
             validateFunc: artifactsValidateFunc
         });
 
+        server.auth.strategy('reject_with_chain', 'bearer-access-token', {
+            validateFunc: alwaysRejectValidateFunc,
+            allowChaining: true
+        });
+
         server.route([
             { method: 'POST', path: '/basic', handler: defaultHandler, config: { auth: 'default' } },
             { method: 'POST', path: '/basic_default_auth', handler: defaultHandler, config: { } },
@@ -126,7 +130,7 @@ before((done) => {
             { method: 'GET', path: '/multiple_headers_enabled', handler: defaultHandler, config: { auth: 'multiple_headers' } },
             { method: 'GET', path: '/custom_token_type', handler: defaultHandler, config: { auth: 'custom_token_type' } },
             { method: 'GET', path: '/artifacts', handler: artifactsValidateFunc, config: { auth: 'artifact_test' } },
-            { method: 'GET', path: '/chain', handler: defaultHandler, config: { auth: { strategies: ['always_reject', 'default'] } } }
+            { method: 'GET', path: '/chain', handler: defaultHandler, config: { auth: { strategies: ['reject_with_chain', 'default'] } } }
         ]);
 
         done();

--- a/test/index.js
+++ b/test/index.js
@@ -124,7 +124,8 @@ before((done) => {
             { method: 'GET', path: '/query_token_enabled', handler: defaultHandler, config: { auth: 'query_token_enabled' } },
             { method: 'GET', path: '/multiple_headers_enabled', handler: defaultHandler, config: { auth: 'multiple_headers' } },
             { method: 'GET', path: '/custom_token_type', handler: defaultHandler, config: { auth: 'custom_token_type' } },
-            { method: 'GET', path: '/artifacts', handler: artifactsValidateFunc, config: { auth: 'artifact_test' } }
+            { method: 'GET', path: '/artifacts', handler: artifactsValidateFunc, config: { auth: 'artifact_test' } },
+            { method: 'GET', path: '/chain', handler: defaultHandler, config: { auth: { strategies: ['always_reject', 'default'] } } }
         ]);
 
         done();
@@ -256,6 +257,11 @@ it('returns 401 handles when isValid false passed to validateFunc', (done) => {
     const request = { method: 'GET', url: '/always_reject', headers: { authorization: 'Bearer 12345678' } };
     server.inject(request, (res) => {
 
+        expect(res.result).to.equal({
+            statusCode: 401,
+            error: 'Unauthorized',
+            message: 'Missing authentication'
+        });
         expect(res.statusCode).to.equal(401);
         done();
     });
@@ -395,6 +401,17 @@ it('accepts artifacts with credentials', (done) => {
 
         expect(res.statusCode).to.equal(200);
         expect(res.request.auth.artifacts.sampleArtifact).equal('artifact');
+        done();
+    });
+});
+
+it('allows chaining of strategies', (done) => {
+
+    const requestHeaderToken  = { method: 'GET', url: '/chain', headers: { authorization: 'Bearer 12345678' } };
+
+    server.inject(requestHeaderToken, (res) => {
+
+        expect(res.statusCode).to.equal(200);
         done();
     });
 });


### PR DESCRIPTION
* Allows chaining
* Added extra check to make sure the `/always_reject` test does not have a message

@johnbrett I'm not familiar with your release process but I'll let you merge (or give a lgtm) and my best bet would be a minor version bump