### PR TITLE
Support for passing token over cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ Bearer authentication requires validating a token passed in by either the bearer
           (e.g. with authentication mode `'try'`).
         - `artifacts` - optional [authentication](http://hapijs.com/tutorials/auth) related data that is not part of the user's credential.
 - `options` - (optional)
-    - `accessTokenName` (Default: 'access_token') - Rename the token query parameter key e.g. 'sample_token_name' would rename the token query parameter to /route1?sample_token_name=12345678.
-    - `allowQueryToken` (Default: true) - Disable accepting token by query parameter, forcing token to be passed in through authorization header.
+    - `accessTokenName` (Default: 'access_token') - Rename the token query/cookie parameter key e.g. 'sample_token_name' would rename the token query parameter to /route1?sample_token_name=12345678.
+    - `allowQueryToken` (Default: true) - Disable accepting token by query parameter, forcing token to be passed in through authorization header or cookie.
+    - `allowCookieToken` (Default: true) - Disable accepting token by cookie parameter, forcing token to be passed in through authorization header or query parameter.
     - `allowMultipleHeaders` (Default: false) - Allow multiple authorization headers in request, e.g. `Authorization: FD AF6C74D1-BBB2-4171-8EE3-7BE9356EB018; Bearer 12345678`
     - `tokenType` (Default: 'Bearer') - Allow custom token type, e.g. `Authorization: Basic 12345678`
     - `allowChaining` (Default: false) - Allow attempt of additonal authentication strategies 

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ internals.implementation = (server, options) => {
 
     options.accessTokenName = options.accessTokenName || 'access_token';
     options.allowQueryToken = options.allowQueryToken === false ? false : true;
+    options.allowCookieToken = options.allowCookieToken === false ? false : true;
     options.allowMultipleHeaders = options.allowMultipleHeaders === true ? true : false;
     options.tokenType = options.tokenType || 'Bearer';
 
@@ -36,6 +37,12 @@ internals.implementation = (server, options) => {
 
             const req = request.raw.req;
             let authorization = req.headers.authorization;
+
+            if (settings.allowCookieToken
+                && !authorization
+                && request.state[settings.accessTokenName] ) {
+                authorization = options.tokenType + ' ' + request.state[settings.accessTokenName];
+            }
 
             if (settings.allowQueryToken
                 && !authorization

--- a/test/index.js
+++ b/test/index.js
@@ -97,6 +97,16 @@ before((done) => {
             allowQueryToken: false
         });
 
+        server.auth.strategy('cookie_token_disabled', 'bearer-access-token', {
+            validateFunc: defaultValidateFunc,
+            allowCookieToken: false
+        });
+
+        server.auth.strategy('cookie_token_enabled', 'bearer-access-token', {
+            validateFunc: defaultValidateFunc,
+            allowCookieToken: true
+        });
+
         server.auth.strategy('multiple_headers', 'bearer-access-token', {
             validateFunc: defaultValidateFunc,
             allowMultipleHeaders: true,
@@ -127,6 +137,8 @@ before((done) => {
             { method: 'GET', path: '/no_credentials', handler: defaultHandler, config: { auth: 'no_credentials' } },
             { method: 'GET', path: '/query_token_disabled', handler: defaultHandler, config: { auth: 'query_token_disabled' } },
             { method: 'GET', path: '/query_token_enabled', handler: defaultHandler, config: { auth: 'query_token_enabled' } },
+            { method: 'GET', path: '/cookie_token_disabled', handler: defaultHandler, config: { auth: 'cookie_token_disabled' } },
+            { method: 'GET', path: '/cookie_token_enabled', handler: defaultHandler, config: { auth: 'cookie_token_enabled' } },
             { method: 'GET', path: '/multiple_headers_enabled', handler: defaultHandler, config: { auth: 'multiple_headers' } },
             { method: 'GET', path: '/custom_token_type', handler: defaultHandler, config: { auth: 'custom_token_type' } },
             { method: 'GET', path: '/artifacts', handler: artifactsValidateFunc, config: { auth: 'artifact_test' } },
@@ -420,6 +432,43 @@ it('allows chaining of strategies', (done) => {
     server.inject(requestHeaderToken, (res) => {
 
         expect(res.statusCode).to.equal(200);
+        done();
+    });
+});
+
+it('returns a 200 on successful with an auth cookie', (done) => {
+
+    const cookie = 'my_access_token=12345678';
+    const requestCookieToken = { method: 'GET', url: '/basic_named_token', headers: { cookie } };
+
+    server.inject(requestCookieToken, (res) => {
+
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.equal('success');
+        done();
+    });
+});
+
+it('allows you to enable auth by cookie token', (done) => {
+
+    const cookie = 'access_token=12345678';
+    const requestCookieToken = { method: 'GET', url: '/cookie_token_enabled', headers: { cookie }  };
+    server.inject(requestCookieToken, (res) => {
+
+        expect(res.statusCode).to.equal(200);
+        expect(res.result).to.equal('success');
+        done();
+    });
+});
+
+
+it('allows you to disable auth by cookie token', (done) => {
+
+    const cookie = 'access_token=12345678';
+    const requestCookieToken  = { method: 'GET', url: '/cookie_token_disabled', headers: { cookie }  };
+    server.inject(requestCookieToken, (res) => {
+
+        expect(res.statusCode).to.equal(401);
         done();
     });
 });


### PR DESCRIPTION
A cookie can be used as transport mechanism for a token.

Name of the cookie is configured through the `accessTokenName` configuration
option. (Same as query parameter).

The feature can be disabled by flipping the `allowQueryToken` configuration
option to false. It's enabled by default

Order of precedence for tokens delivery mechanism is:

 1. Authorization header
 2. Cookie
 3. Query parameter