### PR TITLE
docs: fix readme example comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ server.connection({ port: 8080 });
 server.register(AuthBearer, (err) => {
 
     server.auth.strategy('simple', 'bearer-access-token', {
-        allowQueryToken: true,              // optional, true by default
+        allowQueryToken: true,              // optional, false by default
         allowMultipleHeaders: false,        // optional, false by default
         accessTokenName: 'access_token',    // optional, 'access_token' by default
         validateFunc: function (token, callback) {


### PR DESCRIPTION
Small Readme Fix for the new default value of `allowQueryToken` also in lower the example.