### PR TITLE
Configurable unauthorized function

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Bearer authentication requires validating a token passed in by either the bearer
     - `allowMultipleHeaders` (Default: false) - Allow multiple authorization headers in request, e.g. `Authorization: FD AF6C74D1-BBB2-4171-8EE3-7BE9356EB018; Bearer 12345678`.
     - `tokenType` (Default: 'Bearer') - Allow custom token type, e.g. `Authorization: Basic 12345678`.
     - `allowChaining` (Default: false) - Allow attempt of additional authentication strategies.
+    - `unauthorizedFunc` (Default: Boom.unauthorized) - A function to call when unauthorized with signature `function([message], [scheme], [attributes])`. [More details](https://github.com/hapijs/boom#boomunauthorizedmessage-scheme-attributes)
 
 For convenience, the `request` object can be accessed from `this` within validateFunc. If you want to use this, you must use the `function` keyword instead of the arrow syntax. This allows some greater flexibility with authentication, such different authentication checks for different routes.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,8 @@ internals.defaults = {
     allowCookieToken: false,
     allowMultipleHeaders: false,
     allowChaining: false,
-    tokenType: 'Bearer'
+    tokenType: 'Bearer',
+    unauthorizedFunc: Boom.unauthorized
 };
 
 internals.schema = Joi.object().keys({
@@ -24,7 +25,8 @@ internals.schema = Joi.object().keys({
     allowCookieToken: Joi.boolean(),
     allowMultipleHeaders: Joi.boolean(),
     allowChaining: Joi.boolean(),
-    tokenType: Joi.string().required()
+    tokenType: Joi.string().required(),
+    unauthorizedFunc: Joi.func()
 });
 
 internals.implementation = (server, options) => {
@@ -56,7 +58,7 @@ internals.implementation = (server, options) => {
             }
 
             if (!authorization) {
-                return reply(Boom.unauthorized(null, settings.tokenType));
+                return reply(settings.unauthorizedFunc(null, settings.tokenType));
             }
 
             if (settings.allowMultipleHeaders) {
@@ -69,7 +71,7 @@ internals.implementation = (server, options) => {
             const parts = authorization.split(/\s+/);
 
             if (parts[0].toLowerCase() !== settings.tokenType.toLowerCase()) {
-                return reply(Boom.unauthorized(null, settings.tokenType));
+                return reply(settings.unauthorizedFunc(null, settings.tokenType));
             }
 
             const token = parts[1];
@@ -83,7 +85,7 @@ internals.implementation = (server, options) => {
                 if (!isValid) {
                     const message = (settings.allowChaining && request.route.settings.auth.strategies.length > 1) ? null : 'Bad token';
 
-                    return reply(Boom.unauthorized(message, settings.tokenType), { credentials, artifacts });
+                    return reply(settings.unauthorizedFunc(message, settings.tokenType), { credentials, artifacts });
                 }
 
                 if (!credentials

--- a/test/index.js
+++ b/test/index.js
@@ -133,6 +133,12 @@ before((done) => {
             allowChaining: true
         });
 
+        server.auth.strategy('custom_unauthorized_func', 'bearer-access-token', {
+            validateFunc: alwaysRejectValidateFunc,
+            unauthorizedFunc: (message, schema, attributed) => Boom.notFound(),
+            allowChaining: true
+        });
+
         server.route([
             { method: 'POST', path: '/basic', handler: defaultHandler, config: { auth: 'default' } },
             { method: 'POST', path: '/basic_default_auth', handler: defaultHandler, config: { } },
@@ -148,6 +154,7 @@ before((done) => {
             { method: 'GET', path: '/cookie_token_enabled', handler: defaultHandler, config: { auth: 'cookie_token_enabled' } },
             { method: 'GET', path: '/multiple_headers_enabled', handler: defaultHandler, config: { auth: 'multiple_headers' } },
             { method: 'GET', path: '/custom_token_type', handler: defaultHandler, config: { auth: 'custom_token_type' } },
+            { method: 'GET', path: '/custom_unauthorized_func', handler: defaultHandler, config: { auth: 'custom_unauthorized_func' } },
             { method: 'GET', path: '/artifacts', handler: defaultHandler, config: { auth: 'artifact_test' } },
             { method: 'GET', path: '/chain', handler: defaultHandler, config: { auth: { strategies: ['reject_with_chain', 'default'] } } }
         ]);
@@ -531,3 +538,18 @@ it('allows you to disable auth by cookie token', (done) => {
         done();
     });
 });
+
+it('allows you to use a custom unauthrozied function', (done) => {
+
+    const request = {
+        method: 'GET', url: '/custom_unauthorized_func',
+        headers: { authorization: 'definitelynotacorrecttoken' }
+    };
+
+    server.inject(request, (res) => {
+
+        expect(res.statusCode).to.equal(404);
+        done();
+    });
+});
+


### PR DESCRIPTION
Added support for a custom function that replaces
the default Boom.unauthorized. This inceases flexibility and
allows us, for example, to return a 404 or a 301 in case the
client is unauthorized.