### PR TITLE
Check chain of strategies on default server auth

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,14 @@ internals.implementation = (server, options) => {
                 }
 
                 if (!isValid) {
-                    const message = (settings.allowChaining && request.route.settings.auth.strategies.length > 1) ? null : 'Bad token';
+                    let message = 'Bad token';
+                    if (settings.allowChaining) {
+                        const routeSettings = request.route.settings.auth;
+                        const auth = routeSettings || request.connection.auth.lookup(request.route);
+                        if (auth.strategies.length > 1) {
+                            message = null;
+                        }
+                    }
 
                     return reply(Boom.unauthorized(message, settings.tokenType), { credentials, artifacts });
                 }

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ const expect = Code.expect;
 const before = lab.before;
 const after = lab.after;
 const it = lab.it;
+const describe = lab.describe;
 
 
 const defaultHandler = (request, reply) => {
@@ -47,487 +48,533 @@ const noCredentialValidateFunc = (token, callback) => {
     return callback(null, true, null);
 };
 
+
 const artifactsValidateFunc = (token, callback) => {
 
     return callback(null, true, { token }, { sampleArtifact: 'artifact' });
 };
 
-let server = new Hapi.Server({ debug: false });
-server.connection();
 
+describe('default single strategy', () => {
 
-before((done) => {
+    let server = new Hapi.Server({ debug: false });
+    server.connection();
 
-    server.register(require('../'), (err) => {
+    before((done) => {
 
-        expect(err).to.not.exist();
+        server.register(require('../'), (err) => {
 
-        server.auth.strategy('default', 'bearer-access-token', true, {
-            validateFunc: defaultValidateFunc
+            expect(err).to.not.exist();
+
+            server.auth.strategy('default', 'bearer-access-token', true, {
+                validateFunc: defaultValidateFunc
+            });
+
+            server.auth.strategy('default_named_access_token', 'bearer-access-token', {
+                validateFunc: defaultValidateFunc,
+                accessTokenName: 'my_access_token'
+            });
+
+            server.auth.strategy('always_reject', 'bearer-access-token', {
+                validateFunc: alwaysRejectValidateFunc
+            });
+
+            server.auth.strategy('with_error_strategy', 'bearer-access-token', {
+                validateFunc: alwaysErrorValidateFunc
+            });
+
+            server.auth.strategy('boom_error_strategy', 'bearer-access-token', {
+                validateFunc: boomErrorValidateFunc
+            });
+
+            server.auth.strategy('no_credentials', 'bearer-access-token', {
+                validateFunc: noCredentialValidateFunc
+            });
+
+            server.auth.strategy('query_token_enabled', 'bearer-access-token', {
+                validateFunc: defaultValidateFunc,
+                allowQueryToken: true
+            });
+
+            server.auth.strategy('query_token_enabled_renamed', 'bearer-access-token', {
+                validateFunc: defaultValidateFunc,
+                allowQueryToken: true,
+                accessTokenName: 'my_access_token'
+            });
+
+            server.auth.strategy('query_token_disabled', 'bearer-access-token', {
+                validateFunc: defaultValidateFunc,
+                allowQueryToken: false
+            });
+
+            server.auth.strategy('cookie_token_disabled', 'bearer-access-token', {
+                validateFunc: defaultValidateFunc,
+                allowCookieToken: false
+            });
+
+            server.auth.strategy('cookie_token_enabled', 'bearer-access-token', {
+                validateFunc: defaultValidateFunc,
+                allowCookieToken: true
+            });
+
+            server.auth.strategy('multiple_headers', 'bearer-access-token', {
+                validateFunc: defaultValidateFunc,
+                allowMultipleHeaders: true,
+                tokenType: 'TestToken'
+            });
+
+            server.auth.strategy('custom_token_type', 'bearer-access-token', {
+                validateFunc: defaultValidateFunc,
+                tokenType: 'Basic'
+            });
+
+            server.auth.strategy('artifact_test', 'bearer-access-token', {
+                validateFunc: artifactsValidateFunc
+            });
+
+            server.auth.strategy('reject_with_chain', 'bearer-access-token', {
+                validateFunc: alwaysRejectValidateFunc,
+                allowChaining: true
+            });
+
+            server.route([
+                { method: 'POST', path: '/basic', handler: defaultHandler, config: { auth: 'default' } },
+                { method: 'POST', path: '/basic_default_auth', handler: defaultHandler, config: { } },
+                { method: 'GET', path: '/basic_named_token', handler: defaultHandler, config: { auth: 'default_named_access_token' } },
+                { method: 'GET', path: '/basic_validate_error', handler: defaultHandler, config: { auth: 'with_error_strategy' } },
+                { method: 'GET', path: '/boom_validate_error', handler: defaultHandler, config: { auth: 'boom_error_strategy' } },
+                { method: 'GET', path: '/always_reject', handler: defaultHandler, config: { auth: 'always_reject' } },
+                { method: 'GET', path: '/no_credentials', handler: defaultHandler, config: { auth: 'no_credentials' } },
+                { method: 'GET', path: '/query_token_disabled', handler: defaultHandler, config: { auth: 'query_token_disabled' } },
+                { method: 'GET', path: '/query_token_enabled', handler: defaultHandler, config: { auth: 'query_token_enabled' } },
+                { method: 'GET', path: '/query_token_enabled_renamed', handler: defaultHandler, config: { auth: 'query_token_enabled_renamed' } },
+                { method: 'GET', path: '/cookie_token_disabled', handler: defaultHandler, config: { auth: 'cookie_token_disabled' } },
+                { method: 'GET', path: '/cookie_token_enabled', handler: defaultHandler, config: { auth: 'cookie_token_enabled' } },
+                { method: 'GET', path: '/multiple_headers_enabled', handler: defaultHandler, config: { auth: 'multiple_headers' } },
+                { method: 'GET', path: '/custom_token_type', handler: defaultHandler, config: { auth: 'custom_token_type' } },
+                { method: 'GET', path: '/artifacts', handler: defaultHandler, config: { auth: 'artifact_test' } },
+                { method: 'GET', path: '/chain', handler: defaultHandler, config: { auth: { strategies: ['reject_with_chain', 'default'] } } },
+                { method: 'GET', path: '/chain_single_strategy', handler: defaultHandler, config: { auth: 'reject_with_chain' } }
+            ]);
+
+            done();
         });
+    });
 
-        server.auth.strategy('default_named_access_token', 'bearer-access-token', {
-            validateFunc: defaultValidateFunc,
-            accessTokenName: 'my_access_token'
+    after((done) => {
+
+        server = null;
+        done();
+    });
+
+    it('throws when no bearer options provided', (done) => {
+
+        try {
+            server.auth.strategy('no_options', 'bearer-access-token', true);
+        }
+        catch (e) {
+            expect(e.message).to.equal('Missing bearer auth strategy options');
+            done();
+        }
+    });
+
+    it('throws when validateFunc is not provided', (done) => {
+
+        try {
+            server.auth.strategy('no_options', 'bearer-access-token', true, { validateFunc: 'string' });
+        }
+        catch (e) {
+            expect(e.details[0].message).to.equal('"validateFunc" must be a Function');
+            done();
+        }
+    });
+
+    it('returns 200 and success with correct bearer token header set', (done) => {
+
+        const request = { method: 'POST', url: '/basic', headers: { authorization: 'Bearer 12345678' } };
+
+        server.inject(request, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal('success');
+            done();
         });
+    });
 
-        server.auth.strategy('always_reject', 'bearer-access-token', {
-            validateFunc: alwaysRejectValidateFunc
+    it('returns 200 and success with correct bearer token header set in multiple authorization header', (done) => {
+
+        const request = { method: 'GET', url: '/multiple_headers_enabled', headers: { authorization: 'TestToken 12345678; FD AF6C74D1-BBB2-4171-8EE3-7BE9356EB018' } };
+
+        server.inject(request, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal('success');
+            done();
         });
+    });
 
-        server.auth.strategy('with_error_strategy', 'bearer-access-token', {
-            validateFunc: alwaysErrorValidateFunc
+    it('returns 200 and success with correct bearer token header set in multiple places of the authorization header', (done) => {
+
+        const request = { method: 'GET', url: '/multiple_headers_enabled', headers: { authorization: 'FD AF6C74D1-BBB2-4171-8EE3-7BE9356EB018; TestToken 12345678' } };
+
+        server.inject(request, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal('success');
+            done();
         });
+    });
 
-        server.auth.strategy('boom_error_strategy', 'bearer-access-token', {
-            validateFunc: boomErrorValidateFunc
+    it('returns 401 error with bearer token query param set by default', (done) => {
+
+        const request = { method: 'POST', url: '/basic?access_token=12345678' };
+
+        server.inject(request, (res) => {
+
+            expect(res.statusCode).to.equal(401);
+            done();
         });
+    });
 
-        server.auth.strategy('no_credentials', 'bearer-access-token', {
-            validateFunc: noCredentialValidateFunc
+    it('returns 401 error when no bearer token is set when one is required by default', (done) => {
+
+        const request = { method: 'POST', url: '/basic_default_auth' };
+
+        server.inject(request, (res) => {
+
+            expect(res.statusCode).to.equal(401);
+            done();
         });
+    });
 
-        server.auth.strategy('query_token_enabled', 'bearer-access-token', {
-            validateFunc: defaultValidateFunc,
-            allowQueryToken: true
+    it('returns 401 when bearer authorization header is not set', (done) => {
+
+        const request = { method: 'POST', url: '/basic', headers: { authorization: 'definitelynotacorrecttoken' } };
+
+        server.inject(request, (res) => {
+
+            expect(res.statusCode).to.equal(401);
+            done();
         });
+    });
 
-        server.auth.strategy('query_token_enabled_renamed', 'bearer-access-token', {
-            validateFunc: defaultValidateFunc,
-            allowQueryToken: true,
-            accessTokenName: 'my_access_token'
+    it('returns 401 error with bearer token type of object (invalid token)', (done) => {
+
+        const request = { method: 'POST', url: '/basic', headers: { authorization: 'Bearer {test: 1}' } };
+
+        server.inject(request, (res) => {
+
+            expect(res.statusCode).to.equal(401);
+            done();
         });
+    });
 
-        server.auth.strategy('query_token_disabled', 'bearer-access-token', {
-            validateFunc: defaultValidateFunc,
-            allowQueryToken: false
+    it('returns 500 when strategy returns a regular object to validateFunc', (done) => {
+
+        const request = { method: 'GET', url: '/basic_validate_error', headers: { authorization: 'Bearer 12345678' } };
+        server.inject(request, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(JSON.stringify(res.result)).to.equal('{\"Error\":\"Error\"}');
+            done();
         });
+    });
 
-        server.auth.strategy('cookie_token_disabled', 'bearer-access-token', {
-            validateFunc: defaultValidateFunc,
-            allowCookieToken: false
+    it('returns 500 when strategy returns a Boom error to validateFunc', (done) => {
+
+        const request = { method: 'GET', url: '/boom_validate_error', headers: { authorization: 'Bearer 12345678' } };
+        server.inject(request, (res) => {
+
+            expect(res.statusCode).to.equal(500);
+            expect(JSON.stringify(res.result)).to.equal('{\"statusCode\":500,\"error\":\"Internal Server Error\",\"message\":\"An internal server error occurred\"}');
+            done();
         });
+    });
 
-        server.auth.strategy('cookie_token_enabled', 'bearer-access-token', {
-            validateFunc: defaultValidateFunc,
-            allowCookieToken: true
+    it('returns 401 handles when isValid false passed to validateFunc', (done) => {
+
+        const request = { method: 'GET', url: '/always_reject', headers: { authorization: 'Bearer 12345678' } };
+        server.inject(request, (res) => {
+
+            expect(res.result).to.equal({
+                statusCode: 401,
+                error: 'Unauthorized',
+                message: 'Bad token',
+                attributes: {
+                    error: 'Bad token'
+                }
+            });
+            expect(res.statusCode).to.equal(401);
+            done();
         });
+    });
 
-        server.auth.strategy('multiple_headers', 'bearer-access-token', {
-            validateFunc: defaultValidateFunc,
-            allowMultipleHeaders: true,
-            tokenType: 'TestToken'
+    it('returns 500 when no credentials passed to validateFunc', (done) => {
+
+        const request = { method: 'GET', url: '/no_credentials', headers: { authorization: 'Bearer 12345678' } };
+        server.inject(request, (res) => {
+
+            expect(res.statusCode).to.equal(500);
+            done();
         });
+    });
 
-        server.auth.strategy('custom_token_type', 'bearer-access-token', {
-            validateFunc: defaultValidateFunc,
-            tokenType: 'Basic'
+    it('returns a 401 on default auth with access_token query param renamed and set', (done) => {
+
+        const requestQueryToken = { method: 'GET', url: '/basic_named_token?my_access_token=12345678' };
+        server.inject(requestQueryToken, (res) => {
+
+            expect(res.statusCode).to.equal(401);
+            done();
         });
+    });
 
-        server.auth.strategy('artifact_test', 'bearer-access-token', {
-            validateFunc: artifactsValidateFunc
+    it('doesn\'t affect header auth and will return 200 and success when specifying custom access_token name', (done) => {
+
+        const requestQueryToken = { method: 'GET', url: '/basic_named_token', headers: { authorization: 'Bearer 12345678' } };
+        server.inject(requestQueryToken, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal('success');
+            done();
         });
+    });
 
-        server.auth.strategy('reject_with_chain', 'bearer-access-token', {
-            validateFunc: alwaysRejectValidateFunc,
-            allowChaining: true
+    it('allows you to enable auth by query token', (done) => {
+
+        const requestQueryToken = { method: 'GET', url: '/query_token_enabled?access_token=12345678' };
+        server.inject(requestQueryToken, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal('success');
+            done();
         });
-
-        server.route([
-            { method: 'POST', path: '/basic', handler: defaultHandler, config: { auth: 'default' } },
-            { method: 'POST', path: '/basic_default_auth', handler: defaultHandler, config: { } },
-            { method: 'GET', path: '/basic_named_token', handler: defaultHandler, config: { auth: 'default_named_access_token' } },
-            { method: 'GET', path: '/basic_validate_error', handler: defaultHandler, config: { auth: 'with_error_strategy' } },
-            { method: 'GET', path: '/boom_validate_error', handler: defaultHandler, config: { auth: 'boom_error_strategy' } },
-            { method: 'GET', path: '/always_reject', handler: defaultHandler, config: { auth: 'always_reject' } },
-            { method: 'GET', path: '/no_credentials', handler: defaultHandler, config: { auth: 'no_credentials' } },
-            { method: 'GET', path: '/query_token_disabled', handler: defaultHandler, config: { auth: 'query_token_disabled' } },
-            { method: 'GET', path: '/query_token_enabled', handler: defaultHandler, config: { auth: 'query_token_enabled' } },
-            { method: 'GET', path: '/query_token_enabled_renamed', handler: defaultHandler, config: { auth: 'query_token_enabled_renamed' } },
-            { method: 'GET', path: '/cookie_token_disabled', handler: defaultHandler, config: { auth: 'cookie_token_disabled' } },
-            { method: 'GET', path: '/cookie_token_enabled', handler: defaultHandler, config: { auth: 'cookie_token_enabled' } },
-            { method: 'GET', path: '/multiple_headers_enabled', handler: defaultHandler, config: { auth: 'multiple_headers' } },
-            { method: 'GET', path: '/custom_token_type', handler: defaultHandler, config: { auth: 'custom_token_type' } },
-            { method: 'GET', path: '/artifacts', handler: defaultHandler, config: { auth: 'artifact_test' } },
-            { method: 'GET', path: '/chain', handler: defaultHandler, config: { auth: { strategies: ['reject_with_chain', 'default'] } } }
-        ]);
-
-        done();
     });
-});
 
+    it('allows you to enable auth by query token and rename the query param', (done) => {
 
-after((done) => {
+        const requestQueryToken = { method: 'GET', url: '/query_token_enabled_renamed?my_access_token=12345678' };
+        server.inject(requestQueryToken, (res) => {
 
-    server = null;
-    done();
-});
-
-it('throws when no bearer options provided', (done) => {
-
-    try {
-        server.auth.strategy('no_options', 'bearer-access-token', true);
-    }
-    catch (e) {
-        expect(e.message).to.equal('Missing bearer auth strategy options');
-        done();
-    }
-});
-
-it('throws when validateFunc is not provided', (done) => {
-
-    try {
-        server.auth.strategy('no_options', 'bearer-access-token', true, { validateFunc: 'string' });
-    }
-    catch (e) {
-        expect(e.details[0].message).to.equal('"validateFunc" must be a Function');
-        done();
-    }
-});
-
-it('returns 200 and success with correct bearer token header set', (done) => {
-
-    const request = { method: 'POST', url: '/basic', headers: { authorization: 'Bearer 12345678' } };
-
-    server.inject(request, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        expect(res.result).to.equal('success');
-        done();
-    });
-});
-
-
-it('returns 200 and success with correct bearer token header set in multiple authorization header', (done) => {
-
-    const request = { method: 'GET', url: '/multiple_headers_enabled', headers: { authorization: 'TestToken 12345678; FD AF6C74D1-BBB2-4171-8EE3-7BE9356EB018' } };
-
-    server.inject(request, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        expect(res.result).to.equal('success');
-        done();
-    });
-});
-
-
-it('returns 200 and success with correct bearer token header set in multiple places of the authorization header', (done) => {
-
-    const request = { method: 'GET', url: '/multiple_headers_enabled', headers: { authorization: 'FD AF6C74D1-BBB2-4171-8EE3-7BE9356EB018; TestToken 12345678' } };
-
-    server.inject(request, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        expect(res.result).to.equal('success');
-        done();
-    });
-});
-
-
-it('returns 401 error with bearer token query param set by default', (done) => {
-
-    const request = { method: 'POST', url: '/basic?access_token=12345678' };
-
-    server.inject(request, (res) => {
-
-        expect(res.statusCode).to.equal(401);
-        done();
-    });
-});
-
-
-it('returns 401 error when no bearer token is set when one is required by default', (done) => {
-
-    const request = { method: 'POST', url: '/basic_default_auth' };
-
-    server.inject(request, (res) => {
-
-        expect(res.statusCode).to.equal(401);
-        done();
-    });
-});
-
-
-it('returns 401 when bearer authorization header is not set', (done) => {
-
-    const request = { method: 'POST', url: '/basic', headers: { authorization: 'definitelynotacorrecttoken' } };
-
-    server.inject(request, (res) => {
-
-        expect(res.statusCode).to.equal(401);
-        done();
-    });
-});
-
-
-it('returns 401 error with bearer token type of object (invalid token)', (done) => {
-
-    const request = { method: 'POST', url: '/basic', headers: { authorization: 'Bearer {test: 1}' } };
-
-    server.inject(request, (res) => {
-
-        expect(res.statusCode).to.equal(401);
-        done();
-    });
-});
-
-
-it('returns 500 when strategy returns a regular object to validateFunc', (done) => {
-
-    const request = { method: 'GET', url: '/basic_validate_error', headers: { authorization: 'Bearer 12345678' } };
-    server.inject(request, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        expect(JSON.stringify(res.result)).to.equal('{\"Error\":\"Error\"}');
-        done();
-    });
-});
-
-
-it('returns 500 when strategy returns a Boom error to validateFunc', (done) => {
-
-    const request = { method: 'GET', url: '/boom_validate_error', headers: { authorization: 'Bearer 12345678' } };
-    server.inject(request, (res) => {
-
-        expect(res.statusCode).to.equal(500);
-        expect(JSON.stringify(res.result)).to.equal('{\"statusCode\":500,\"error\":\"Internal Server Error\",\"message\":\"An internal server error occurred\"}');
-        done();
-    });
-});
-
-
-it('returns 401 handles when isValid false passed to validateFunc', (done) => {
-
-    const request = { method: 'GET', url: '/always_reject', headers: { authorization: 'Bearer 12345678' } };
-    server.inject(request, (res) => {
-
-        expect(res.result).to.equal({
-            statusCode: 401,
-            error: 'Unauthorized',
-            message: 'Bad token',
-            attributes: {
-                error: 'Bad token'
-            }
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal('success');
+            done();
         });
-        expect(res.statusCode).to.equal(401);
-        done();
+    });
+
+    it('allows you to enable auth by query token and still use header', (done) => {
+
+        const requestQueryToken = { method: 'GET', url: '/query_token_enabled_renamed', headers: { authorization: 'Bearer 12345678' } };
+        server.inject(requestQueryToken, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal('success');
+            done();
+        });
+    });
+
+    it('allows you to disable auth by query token', (done) => {
+
+        const requestHeaderToken  = { method: 'GET', url: '/query_token_disabled?access_token=12345678' };
+        server.inject(requestHeaderToken, (res) => {
+
+            expect(res.statusCode).to.equal(401);
+            done();
+        });
+    });
+
+    it('disables multiple auth headers by default', (done) => {
+
+        const request = { method: 'POST', url: '/basic', headers: { authorization: 'RandomAuthHeader 1234; TestToken 12345678' } };
+        server.inject(request, (res) => {
+
+            expect(res.statusCode).to.equal(401);
+            done();
+        });
+    });
+
+    it('allows you to enable multiple auth headers', (done) => {
+
+        const requestHeaderToken = { method: 'GET', url: '/multiple_headers_enabled', headers: { authorization: 'RandomAuthHeader 1234; TestToken 12345678' } };
+        server.inject(requestHeaderToken, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+    it('return unauthorized when no auth info and multiple headers disabled', (done) => {
+
+        const requestHeaderToken = { method: 'POST', url: '/basic', headers: { authorization: 'x' } };
+        server.inject(requestHeaderToken, (res) => {
+
+            expect(res.statusCode).to.equal(401);
+            done();
+        });
+    });
+
+    it('return unauthorized when no auth info and multiple headers enabled', (done) => {
+
+        const requestHeaderToken = { method: 'GET', url: '/multiple_headers_enabled', headers: { authorization: 'x' } };
+        server.inject(requestHeaderToken, (res) => {
+
+            expect(res.statusCode).to.equal(401);
+            done();
+        });
+    });
+
+    it('return unauthorized when different token type is used', (done) => {
+
+        const requestHeaderToken = { method: 'GET', url: '/custom_token_type', headers: { authorization: 'Bearer 12345678' } };
+
+        server.inject(requestHeaderToken, (res) => {
+
+            expect(res.statusCode).to.equal(401);
+            done();
+        });
+    });
+
+    it('return 200 when correct token type is used', (done) => {
+
+        const requestHeaderToken  = { method: 'GET', url: '/custom_token_type', headers: { authorization: 'Basic 12345678' } };
+
+        server.inject(requestHeaderToken, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+    it('accepts artifacts with credentials', (done) => {
+
+        const requestHeaderToken  = { method: 'GET', url: '/artifacts', headers: { authorization: 'Bearer 12345678' } };
+
+        server.inject(requestHeaderToken, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.request.auth.artifacts.sampleArtifact).equal('artifact');
+            done();
+        });
+    });
+
+    it('return 200 with a chain of strategies', (done) => {
+
+        const requestHeaderToken  = { method: 'GET', url: '/chain', headers: { authorization: 'Bearer 12345678' } };
+
+        server.inject(requestHeaderToken, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+    it('return 401 with allowChaining and a single strategy', (done) => {
+
+        const requestHeaderToken  = { method: 'GET', url: '/chain_single_strategy', headers: { authorization: 'Bearer 12345678' } };
+
+        server.inject(requestHeaderToken, (res) => {
+
+            expect(res.statusCode).to.equal(401);
+            done();
+        });
+    });
+
+    it('does not allow an auth cookie by default', (done) => {
+
+        const cookie = 'my_access_token=12345678';
+        const requestCookieToken = { method: 'GET', url: '/basic_named_token', headers: { cookie } };
+
+        server.inject(requestCookieToken, (res) => {
+
+            expect(res.statusCode).to.equal(401);
+            done();
+        });
+    });
+
+    it('allows you to enable auth by cookie token', (done) => {
+
+        const cookie = 'access_token=12345678';
+        const requestCookieToken = { method: 'GET', url: '/cookie_token_enabled', headers: { cookie }  };
+        server.inject(requestCookieToken, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            expect(res.result).to.equal('success');
+            done();
+        });
+    });
+
+    it('will ignore cookie value if header auth provided', (done) => {
+
+        const cookie = 'my_access_token=12345678';
+        const authorization = 'Bearer 12345678';
+        const requestCookieToken = { method: 'GET', url: '/cookie_token_enabled', headers: { authorization, cookie } };
+
+        server.inject(requestCookieToken, (res) => {
+
+            expect(res.statusCode).to.equal(200);
+            done();
+        });
+    });
+
+    it('allows you to disable auth by cookie token', (done) => {
+
+        const cookie = 'access_token=12345678';
+        const requestCookieToken  = { method: 'GET', url: '/cookie_token_disabled', headers: { cookie }  };
+        server.inject(requestCookieToken, (res) => {
+
+            expect(res.statusCode).to.equal(401);
+            done();
+        });
     });
 });
 
+describe('default chain of strategies', () => {
 
-it('returns 500 when no credentials passed to validateFunc', (done) => {
+    let server = new Hapi.Server({ debug: false });
+    server.connection();
 
-    const request = { method: 'GET', url: '/no_credentials', headers: { authorization: 'Bearer 12345678' } };
-    server.inject(request, (res) => {
+    before((done) => {
 
-        expect(res.statusCode).to.equal(500);
+        server.register(require('../'), (err) => {
+
+            expect(err).to.not.exist();
+
+            server.auth.strategy('default', 'bearer-access-token', {
+                validateFunc: defaultValidateFunc
+            });
+
+            server.auth.strategy('reject_with_chain', 'bearer-access-token', {
+                validateFunc: alwaysRejectValidateFunc,
+                allowChaining: true
+            });
+
+            server.route({ method: 'GET', path: '/chain', handler: defaultHandler });
+
+            server.auth.default({
+                strategies: [
+                    'reject_with_chain',
+                    'default'
+                ]
+            });
+
+            done();
+        });
+    });
+
+    after((done) => {
+
+        server = null;
         done();
     });
-});
 
+    it('return 200 with a chain of strategies', (done) => {
 
-it('returns a 401 on default auth with access_token query param renamed and set', (done) => {
+        const requestHeaderToken  = { method: 'GET', url: '/chain', headers: { authorization: 'Bearer 12345678' } };
 
-    const requestQueryToken = { method: 'GET', url: '/basic_named_token?my_access_token=12345678' };
-    server.inject(requestQueryToken, (res) => {
+        server.inject(requestHeaderToken, (res) => {
 
-        expect(res.statusCode).to.equal(401);
-        done();
-    });
-});
-
-
-it('doesn\'t affect header auth and will return 200 and success when specifying custom access_token name', (done) => {
-
-    const requestQueryToken = { method: 'GET', url: '/basic_named_token', headers: { authorization: 'Bearer 12345678' } };
-    server.inject(requestQueryToken, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        expect(res.result).to.equal('success');
-        done();
-    });
-});
-
-
-it('allows you to enable auth by query token', (done) => {
-
-    const requestQueryToken = { method: 'GET', url: '/query_token_enabled?access_token=12345678' };
-    server.inject(requestQueryToken, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        expect(res.result).to.equal('success');
-        done();
-    });
-});
-
-it('allows you to enable auth by query token and rename the query param', (done) => {
-
-    const requestQueryToken = { method: 'GET', url: '/query_token_enabled_renamed?my_access_token=12345678' };
-    server.inject(requestQueryToken, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        expect(res.result).to.equal('success');
-        done();
-    });
-});
-
-it('allows you to enable auth by query token and still use header', (done) => {
-
-    const requestQueryToken = { method: 'GET', url: '/query_token_enabled_renamed', headers: { authorization: 'Bearer 12345678' } };
-    server.inject(requestQueryToken, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        expect(res.result).to.equal('success');
-        done();
-    });
-});
-
-
-it('allows you to disable auth by query token', (done) => {
-
-    const requestHeaderToken  = { method: 'GET', url: '/query_token_disabled?access_token=12345678' };
-    server.inject(requestHeaderToken, (res) => {
-
-        expect(res.statusCode).to.equal(401);
-        done();
-    });
-});
-
-
-it('disables multiple auth headers by default', (done) => {
-
-    const request = { method: 'POST', url: '/basic', headers: { authorization: 'RandomAuthHeader 1234; TestToken 12345678' } };
-    server.inject(request, (res) => {
-
-        expect(res.statusCode).to.equal(401);
-        done();
-    });
-});
-
-it('allows you to enable multiple auth headers', (done) => {
-
-    const requestHeaderToken = { method: 'GET', url: '/multiple_headers_enabled', headers: { authorization: 'RandomAuthHeader 1234; TestToken 12345678' } };
-    server.inject(requestHeaderToken, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        done();
-    });
-});
-
-
-it('return unauthorized when no auth info and multiple headers disabled', (done) => {
-
-    const requestHeaderToken = { method: 'POST', url: '/basic', headers: { authorization: 'x' } };
-    server.inject(requestHeaderToken, (res) => {
-
-        expect(res.statusCode).to.equal(401);
-        done();
-    });
-});
-
-
-it('return unauthorized when no auth info and multiple headers enabled', (done) => {
-
-    const requestHeaderToken = { method: 'GET', url: '/multiple_headers_enabled', headers: { authorization: 'x' } };
-    server.inject(requestHeaderToken, (res) => {
-
-        expect(res.statusCode).to.equal(401);
-        done();
-    });
-});
-
-
-it('return unauthorized when different token type is used', (done) => {
-
-    const requestHeaderToken = { method: 'GET', url: '/custom_token_type', headers: { authorization: 'Bearer 12345678' } };
-
-    server.inject(requestHeaderToken, (res) => {
-
-        expect(res.statusCode).to.equal(401);
-        done();
-    });
-});
-
-
-it('return 200 when correct token type is used', (done) => {
-
-    const requestHeaderToken  = { method: 'GET', url: '/custom_token_type', headers: { authorization: 'Basic 12345678' } };
-
-    server.inject(requestHeaderToken, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        done();
-    });
-});
-
-
-it('accepts artifacts with credentials', (done) => {
-
-    const requestHeaderToken  = { method: 'GET', url: '/artifacts', headers: { authorization: 'Bearer 12345678' } };
-
-    server.inject(requestHeaderToken, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        expect(res.request.auth.artifacts.sampleArtifact).equal('artifact');
-        done();
-    });
-});
-
-it('allows chaining of strategies', (done) => {
-
-    const requestHeaderToken  = { method: 'GET', url: '/chain', headers: { authorization: 'Bearer 12345678' } };
-
-    server.inject(requestHeaderToken, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        done();
-    });
-});
-
-it('does not allow an auth cookie by default', (done) => {
-
-    const cookie = 'my_access_token=12345678';
-    const requestCookieToken = { method: 'GET', url: '/basic_named_token', headers: { cookie } };
-
-    server.inject(requestCookieToken, (res) => {
-
-        expect(res.statusCode).to.equal(401);
-        done();
-    });
-});
-
-it('allows you to enable auth by cookie token', (done) => {
-
-    const cookie = 'access_token=12345678';
-    const requestCookieToken = { method: 'GET', url: '/cookie_token_enabled', headers: { cookie }  };
-    server.inject(requestCookieToken, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        expect(res.result).to.equal('success');
-        done();
-    });
-});
-
-it('will ignore cookie value if header auth provided', (done) => {
-
-    const cookie = 'my_access_token=12345678';
-    const authorization = 'Bearer 12345678';
-    const requestCookieToken = { method: 'GET', url: '/cookie_token_enabled', headers: { authorization, cookie } };
-
-    server.inject(requestCookieToken, (res) => {
-
-        expect(res.statusCode).to.equal(200);
-        done();
-    });
-});
-
-it('allows you to disable auth by cookie token', (done) => {
-
-    const cookie = 'access_token=12345678';
-    const requestCookieToken  = { method: 'GET', url: '/cookie_token_disabled', headers: { cookie }  };
-    server.inject(requestCookieToken, (res) => {
-
-        expect(res.statusCode).to.equal(401);
-        done();
+            expect(res.statusCode).to.equal(200);
+            done();
+        });
     });
 });


### PR DESCRIPTION
Currently when `allowChaining` is enabled, it looks for a chain of `strategies` on the route configuration. When a chain is set as default server auth, it breaks execution and returns `401`.

P.S. Sorry for all the whitespace line changes -- I've created a new suite for these cases with a fresh server instance.