### PR TITLE
Update peerDependencies to new module location

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@hapi/joi": "^15.0.3"
   },
   "peerDependencies": {
-    "hapi": ">=17.x.x"
+    "@hapi/hapi": ">=17.x.x"
   },
   "devDependencies": {
     "@hapi/code": "^5.3.1",


### PR DESCRIPTION
To avoid the [peer dependency unmet warning](https://github.com/johnbrett/hapi-auth-bearer-token/pull/183#issuecomment-495551109)