### PR TITLE
bug: don't throw h.unauthenticated

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,7 @@ internals.implementation = (server, options) => {
 
             if (!credentials
                 || typeof credentials !== 'object') {
-                throw h.unauthenticated(Boom.badImplementation('Bad token string received for Bearer auth validation'), { credentials: {} });
+                return h.unauthenticated(Boom.badImplementation('Bad token string received for Bearer auth validation'), { credentials: {} });
             }
 
             return h.authenticated({ credentials, artifacts });


### PR DESCRIPTION
bug: don't throw h.unauthenticated

When throwing h.unathenticated, hapi will intercept that error, and
replace it with its own 500 error:

Debug: internal, implementation, error
    Error: Cannot throw non-error object

This makes debugging a broken validate function very confusing, because
hapi eats "bad token string [..]" error message and replaces it with the
above.